### PR TITLE
changed the format syntax to correct the ValueError exception thrown

### DIFF
--- a/python/ember/input.py
+++ b/python/ember/input.py
@@ -1306,9 +1306,9 @@ class ConcreteConfig(_ember.ConfigOptions):
         for a in strainRates:
             aSave.append(a)
 
-            restartFile = 'prof_eps{:04i}.{}'.format(a, fileExt)
-            historyFile = 'out_eps{:04i}.{}'.format(a, fileExt)
-            configFile = 'conf_eps{:04i}.{}'.format(a, fileExt)
+            restartFile = 'prof_eps{:04d}.{}'.format(a, fileExt)
+            historyFile = 'out_eps{:04d}.{}'.format(a, fileExt)
+            configFile = 'conf_eps{:04d}.{}'.format(a, fileExt)
 
             restartPath = os.path.join(self.paths.outputDir, restartFile)
             historyPath = os.path.join(self.paths.outputDir, historyFile)


### PR DESCRIPTION
I get this error when I attempt Ember multiruns (for a bunch of strain rates):
    restartFile = 'prof_eps{:04i}.{}'.format(a, fileExt)
ValueError: Unknown format code 'i' for object of type 'int'
