### PR TITLE
Asymmetric jet flames & moving strain terms

### DIFF
--- a/doc/src/1dflameV2-users-guide.lyx
+++ b/doc/src/1dflameV2-users-guide.lyx
@@ -398,7 +398,7 @@ centering
 \begin_layout Plain Layout
 \begin_inset CommandInset label
 LatexCommand label
-name "cap:CurvedFlameZero"
+name "cap:cylindricalFlameZero"
 
 \end_inset
 
@@ -427,7 +427,7 @@ The curved flame at zero stagnation radius is quite similar to the twin
  This configuration is shown in Figure 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "cap:CurvedFlameZero"
+reference "cap:cylindricalFlameZero"
 
 \end_inset
 
@@ -496,7 +496,7 @@ status open
 \begin_layout Plain Layout
 \begin_inset CommandInset label
 LatexCommand label
-name "cap:CurvedFlameFinite"
+name "cap:cylindricalFlameFinite"
 
 \end_inset
 
@@ -525,7 +525,7 @@ The tubular flame at zero stagnation radius can be modified by introducing
 , as shown in Figure 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "cap:CurvedFlameFinite"
+reference "cap:cylindricalFlameFinite"
 
 \end_inset
 

--- a/doc/src/ember-model.lyx
+++ b/doc/src/ember-model.lyx
@@ -378,7 +378,7 @@ centering
 \begin_layout Plain Layout
 \begin_inset CommandInset label
 LatexCommand label
-name "cap:CurvedFlameZero"
+name "cap:cylindricalFlameZero"
 
 \end_inset
 
@@ -407,7 +407,7 @@ The curved flame at zero stagnation radius is quite similar to the twin
  This configuration is shown in Figure 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "cap:CurvedFlameZero"
+reference "cap:cylindricalFlameZero"
 
 \end_inset
 
@@ -476,7 +476,7 @@ status open
 \begin_layout Plain Layout
 \begin_inset CommandInset label
 LatexCommand label
-name "cap:CurvedFlameFinite"
+name "cap:cylindricalFlameFinite"
 
 \end_inset
 
@@ -505,7 +505,7 @@ The tubular flame at zero stagnation radius can be modified by introducing
 , as shown in Figure 
 \begin_inset CommandInset ref
 LatexCommand ref
-reference "cap:CurvedFlameFinite"
+reference "cap:cylindricalFlameFinite"
 
 \end_inset
 

--- a/python/ember/_ember.pxd
+++ b/python/ember/_ember.pxd
@@ -47,8 +47,8 @@ cdef extern from "readConfig.h":
         string outputDir
         cbool fixedBurnedVal, fixedLeftLoc, twinFlame
         int continuityBC
-        cbool curvedFlame, unburnedLeft, fuelLeft
-        cbool axiJetFlame
+        cbool cylindricalFlame, unburnedLeft, fuelLeft
+        cbool discFlame
         string flameType
         int regridStepInterval, outputStepInterval, profileStepInterval
         int currentStateStepInterval, terminateStepInterval

--- a/python/ember/_ember.pxd
+++ b/python/ember/_ember.pxd
@@ -47,9 +47,8 @@ cdef extern from "readConfig.h":
         string outputDir
         cbool fixedBurnedVal, fixedLeftLoc, twinFlame
         int continuityBC
-        cbool cylindricalFlame, unburnedLeft, fuelLeft
-        cbool discFlame
-        string flameType
+        cbool cylindricalFlame, discFlame, unburnedLeft, fuelLeft
+        string flameType, flameGeometry
         int regridStepInterval, outputStepInterval, profileStepInterval
         int currentStateStepInterval, terminateStepInterval
         double regridTimeInterval, outputTimeInterval, profileTimeInterval

--- a/python/ember/_ember.pxd
+++ b/python/ember/_ember.pxd
@@ -48,6 +48,7 @@ cdef extern from "readConfig.h":
         cbool fixedBurnedVal, fixedLeftLoc, twinFlame
         int continuityBC
         cbool curvedFlame, unburnedLeft, fuelLeft
+        cbool axiJetFlame
         string flameType
         int regridStepInterval, outputStepInterval, profileStepInterval
         int currentStateStepInterval, terminateStepInterval
@@ -93,6 +94,7 @@ cdef extern from "readConfig.h":
         cbool haveTStart
 
         int gridAlpha
+        int gridBeta
 
         cbool outputProfiles
 
@@ -133,6 +135,7 @@ cdef extern from "grid.h":
     cdef cppclass CxxOneDimGrid "OneDimGrid":
         CxxEigenVec x
         int alpha
+        int beta
         CxxEigenVec cfp, cf, cfm, hh, rphalf
 
 

--- a/python/ember/_ember.pyx
+++ b/python/ember/_ember.pyx
@@ -178,9 +178,9 @@ cdef class ConfigOptions:
         opts.unburnedLeft = G.unburnedLeft
         opts.fuelLeft = G.fuelLeft
         opts.nThreads = G.nThreads
-        opts.cylindricalFlame = G.cylindricalFlame
+        opts.cylindricalFlame = 1 if G.flameGeometry == 'cylindrical' else 0
         opts.gridAlpha = 1 if opts.cylindricalFlame else 0
-        opts.discFlame = G.discFlame
+        opts.discFlame = 1 if G.flameGeometry == 'disc' else 0
         opts.gridBeta = 1 if opts.discFlame else 0
         opts.twinFlame = G.twinFlame
         opts.chemistryIntegrator = G.chemistryIntegrator

--- a/python/ember/_ember.pyx
+++ b/python/ember/_ember.pyx
@@ -180,6 +180,8 @@ cdef class ConfigOptions:
         opts.nThreads = G.nThreads
         opts.curvedFlame = G.curvedFlame
         opts.gridAlpha = 1 if opts.curvedFlame else 0
+        opts.axiJetFlame = G.axiJetFlame
+        opts.gridBeta = 1 if opts.axiJetFlame else 0
         opts.twinFlame = G.twinFlame
         opts.chemistryIntegrator = G.chemistryIntegrator
         opts.splittingMethod = G.splittingMethod
@@ -547,6 +549,10 @@ cdef class FlameSolver:
     property gridAlpha:
         def __get__(self):
             return self.solver.grid.alpha
+
+    property gridBeta:
+        def __get__(self):
+            return self.solver.grid.beta
 
     property T:
         def __get__(self):

--- a/python/ember/_ember.pyx
+++ b/python/ember/_ember.pyx
@@ -178,10 +178,10 @@ cdef class ConfigOptions:
         opts.unburnedLeft = G.unburnedLeft
         opts.fuelLeft = G.fuelLeft
         opts.nThreads = G.nThreads
-        opts.curvedFlame = G.curvedFlame
-        opts.gridAlpha = 1 if opts.curvedFlame else 0
-        opts.axiJetFlame = G.axiJetFlame
-        opts.gridBeta = 1 if opts.axiJetFlame else 0
+        opts.cylindricalFlame = G.cylindricalFlame
+        opts.gridAlpha = 1 if opts.cylindricalFlame else 0
+        opts.discFlame = G.discFlame
+        opts.gridBeta = 1 if opts.discFlame else 0
         opts.twinFlame = G.twinFlame
         opts.chemistryIntegrator = G.chemistryIntegrator
         opts.splittingMethod = G.splittingMethod

--- a/python/ember/input.py
+++ b/python/ember/input.py
@@ -284,6 +284,10 @@ class General(Options):
     curvedFlame = BoolOption(False,
         filter=lambda conf: not conf.general.twinFlame)
 
+    #: True if solving an axisymmetric jet flame in cylindrical coordinate system.
+    axiJetFlame = BoolOption(False,
+                             filter=lambda conf: not conf.general.curvedFlame)
+
     #: True if solving a planar flame that is symmetric about the x = 0 plane.
     twinFlame = BoolOption(False,
         filter=lambda conf: not conf.general.curvedFlame)
@@ -901,6 +905,11 @@ class Config(object):
         if self.general.curvedFlame and self.general.twinFlame:
             error = True
             print "Error: 'twinFlame' and 'curvedFlame' are mutually exclusive."
+
+        # axiJetFlame and curvedFlame are mutually exclusive:
+        if self.general.curvedFlame and self.general.axiJetFlame:
+            error = True
+            print "Error: 'axiJetFlame' and 'curvedFlame' are mutually exclusive."
 
         # the "fuelLeft" option only makes sense for diffusion flames
         if (self.initialCondition.flameType == 'premixed' and

--- a/python/ember/input.py
+++ b/python/ember/input.py
@@ -233,7 +233,7 @@ def _isDiffusion(conf):
 
 
 def _isSymmetric(conf):
-    return conf.general.curvedFlame or conf.general.twinFlame
+    return conf.general.cylindricalFlame or conf.general.twinFlame
 
 
 def _usingCvode(conf):
@@ -281,16 +281,16 @@ class General(Options):
 
     #: True if solving a radially propagating flame in a cylindrical
     #: coordinate system.
-    curvedFlame = BoolOption(False,
-        filter=lambda conf: not conf.general.twinFlame)
+    cylindricalFlame = BoolOption(False,
+                                  filter=lambda conf: not conf.general.twinFlame)
 
     #: True if solving an axisymmetric jet flame in cylindrical coordinate system.
-    axiJetFlame = BoolOption(False,
-                             filter=lambda conf: not conf.general.curvedFlame)
+    discFlame = BoolOption(False,
+                           filter=lambda conf: not conf.general.cylindricalFlame)
 
     #: True if solving a planar flame that is symmetric about the x = 0 plane.
     twinFlame = BoolOption(False,
-        filter=lambda conf: not conf.general.curvedFlame)
+        filter=lambda conf: not conf.general.cylindricalFlame)
 
     #: Input file (HDF5 format) containing the interpolation data needed for
     #: the quasi2d mode. Contains:
@@ -896,20 +896,20 @@ class Config(object):
         # Position control can only be used with "twin" or "curved" flames
         if (self.positionControl is not None and
             not self.general.twinFlame and
-            not self.general.curvedFlame):
+            not self.general.cylindricalFlame):
             error = True
             print ("Error: PositionControl can only be used when either 'twinFlame'\n"
-                   "       or 'curvedFlame' is set to True.")
+                   "       or 'cylindricalFlame' is set to True.")
 
-        # twinFlame and curvedFlame are mutually exclusive:
-        if self.general.curvedFlame and self.general.twinFlame:
+        # twinFlame and cylindricalFlame are mutually exclusive:
+        if self.general.cylindricalFlameFlame and self.general.twinFlame:
             error = True
-            print "Error: 'twinFlame' and 'curvedFlame' are mutually exclusive."
+            print "Error: 'twinFlame' and 'cylindricalFlame' are mutually exclusive."
 
-        # axiJetFlame and curvedFlame are mutually exclusive:
-        if self.general.curvedFlame and self.general.axiJetFlame:
+        # discFlame and cylindricalFlame are mutually exclusive:
+        if self.general.cylindricalFlame and self.general.discFlame:
             error = True
-            print "Error: 'axiJetFlame' and 'curvedFlame' are mutually exclusive."
+            print "Error: 'discFlame' and 'cylindricalFlame' are mutually exclusive."
 
         # the "fuelLeft" option only makes sense for diffusion flames
         if (self.initialCondition.flameType == 'premixed' and
@@ -1033,7 +1033,7 @@ class ConcreteConfig(_ember.ConfigOptions):
                                     self.chemistry.phaseID)
 
         if self.general.fixedBurnedVal is None:
-            if ((self.general.twinFlame or self.general.curvedFlame)
+            if ((self.general.twinFlame or self.general.cylindricalFlame)
                 and not self.general.unburnedLeft):
                 self.general.fixedBurnedVal = False
             else:
@@ -1151,7 +1151,7 @@ class ConcreteConfig(_ember.ConfigOptions):
         N = IC.nPoints
         gas = self.gas
 
-        xLeft = (0.0 if self.general.twinFlame or self.general.curvedFlame
+        xLeft = (0.0 if self.general.twinFlame or self.general.cylindricalFlame
                  else IC.xLeft)
 
         x = np.linspace(xLeft, IC.xRight, N)
@@ -1232,7 +1232,7 @@ class ConcreteConfig(_ember.ConfigOptions):
         for _ in range(2):
             utils.smooth(U)
 
-        if self.general.twinFlame or self.general.curvedFlame:
+        if self.general.twinFlame or self.general.cylindricalFlame:
             # Stagnation point at x = 0
             V[0] = 0
             for j in range(1, N):

--- a/src/convectionSystem.cpp
+++ b/src/convectionSystem.cpp
@@ -21,22 +21,23 @@ int ConvectionSystemUTW::f(const realtype t, const sdVector& y, sdVector& ydot)
     rho = gas->pressure * Wmx / (Cantera::GasConstant * T);
 
     // *** Calculate V ***
+    //aelong added beta for axiJetflames
     if (continuityBC == ContinuityBoundaryCondition::Left) {
         rV[0] = rVzero;
         for (size_t j=0; j<nPoints-1; j++) {
-            rV[j+1] = rV[j] - hh[j] * (drhodt[j] + rho[j] * U[j] * rphalf[j]);
+            rV[j+1] = rV[j] - hh[j] * (drhodt[j] + rho[j] * pow(2.0,grid.beta)* U[j] * rphalf[j]);
         }
     } else if (continuityBC == ContinuityBoundaryCondition::Zero) {
         // jContBC is the point just to the right of the stagnation point
         size_t j = jContBC;
-        double dVdx0 = - drhodt[j] - rho[j] * U[j] * rphalf[j];
+        double dVdx0 = - drhodt[j] - rho[j] * pow(2.0,grid.beta)* U[j] * rphalf[j];
         if (jContBC != 0) {
-            dVdx0 = 0.5 * dVdx0 - 0.5 * (drhodt[j-1] + rho[j-1] * U[j-1] * rphalf[j-1]);
+            dVdx0 = 0.5 * dVdx0 - 0.5 * (drhodt[j-1] + rho[j-1] * pow(2.0,grid.beta)* U[j-1] * rphalf[j-1]);
         }
 
         rV[j] = (x[j] - xVzero) * dVdx0;
         for (j=jContBC; j<jj; j++) {
-            rV[j+1] = rV[j] - hh[j] * (drhodt[j] + rho[j] * U[j] * rphalf[j]);
+            rV[j+1] = rV[j] - hh[j] * (drhodt[j] + rho[j] * pow(2.0,grid.beta)* U[j] * rphalf[j]);
         }
 
         if (jContBC != 0) {
@@ -44,7 +45,7 @@ int ConvectionSystemUTW::f(const realtype t, const sdVector& y, sdVector& ydot)
 //            dVdx0 = - drhodt[j] - rho[j] * U[j] * rphalf[j];
             rV[j] = (x[j] - xVzero) * dVdx0;
             for (j=jContBC-1; j>0; j--) {
-                rV[j-1] = rV[j] + hh[j-1] * (drhodt[j-1] + rho[j-1] * U[j-1] * rphalf[j-1]);
+                rV[j-1] = rV[j] + hh[j-1] * (drhodt[j-1] + rho[j-1] * pow(2.0,grid.beta)* U[j-1] * rphalf[j-1]);
             }
         }
     } else {
@@ -59,10 +60,10 @@ int ConvectionSystemUTW::f(const realtype t, const sdVector& y, sdVector& ydot)
             }
         }
         for (size_t j=jContBC; j<nPoints-1; j++) {
-            rV[j+1] = rV[j] - hh[j] * (drhodt[j] + rho[j] * U[j] * rphalf[j]);
+            rV[j+1] = rV[j] - hh[j] * (drhodt[j] + rho[j] * pow(2.0,grid.beta)* U[j] * rphalf[j]);
         }
         for (size_t j=jContBC; j>0; j--) {
-            rV[j-1] = rV[j] + hh[j-1] * (drhodt[j] + rho[j] * U[j] * rphalf[j]);
+            rV[j-1] = rV[j] + hh[j-1] * (drhodt[j] + rho[j] * pow(2.0,grid.beta)* U[j] * rphalf[j]);
         }
     }
 
@@ -119,7 +120,7 @@ int ConvectionSystemUTW::f(const realtype t, const sdVector& y, sdVector& ydot)
         // Outflow  at the boundary
         dUdt[jj] = splitConstU[jj] - V[jj] * (U[jj]-U[jj-1])/hh[jj-1]/rho[jj];
         dTdt[jj] = splitConstT[jj] - V[jj] * (T[jj]-T[jj-1])/hh[jj-1]/rho[jj];
-       dWdt[jj] = splitConstW[jj] - V[jj] * (Wmx[jj]-Wmx[jj-1])/hh[jj-1]/rho[jj];
+        dWdt[jj] = splitConstW[jj] - V[jj] * (Wmx[jj]-Wmx[jj-1])/hh[jj-1]/rho[jj];
     }
 
     roll_ydot(ydot);

--- a/src/convectionSystem.h
+++ b/src/convectionSystem.h
@@ -5,6 +5,7 @@
 #include "grid.h"
 #include "perfTimer.h"
 #include "quasi2d.h"
+#include "scalarFunction.h"
 
 #include <boost/shared_ptr.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
@@ -80,6 +81,17 @@ public:
     ContinuityBoundaryCondition::BC continuityBC;
     size_t jContBC; //!< The point at which the continuity equation BC is applied.
     double xVzero; //!< Location of the stagnation point (if using fixedZero BC)
+
+    //! An object that provides the strain rate and its time derivative
+    ScalarFunction* strainFunction;
+
+    //! Set the function used to compute the strain rate as a function of time
+    void setStrainFunction(ScalarFunction* f) { strainFunction = f; }
+
+    //! Set the density of the unburned mixture.
+    //! This value appears in the source term of the momentum equation.
+    double rhou; //!< density of the unburned gas
+    void setRhou(double _rhou) { rhou = _rhou; }
 
 private:
     void V2rV(); //!< compute #rV from #V

--- a/src/flameSolver.cpp
+++ b/src/flameSolver.cpp
@@ -625,7 +625,7 @@ void FlameSolver::updateBC()
         grid.leftBC = BoundaryCondition::WallFlux;
     } else if (grid.ju == 0 || (grid.jb == 0 && grid.fixedBurnedVal)) {
         grid.leftBC = BoundaryCondition::FixedValue;
-    } else if ((options.twinFlame || options.curvedFlame) &&
+    } else if ((options.twinFlame || options.cylindricalFlame) &&
                 x[0] >= 0.0 && x[0] <= options.centerGridMin) {
         grid.leftBC = BoundaryCondition::ControlVolume;
     } else {
@@ -945,8 +945,8 @@ double FlameSolver::getFlamePosition(void)
 
 void FlameSolver::loadProfile(void)
 {
-    grid.alpha = (options.curvedFlame) ? 1 : 0;
-    grid.beta = (options.axiJetFlame) ? 1 : 0;
+    grid.alpha = (options.cylindricalFlame) ? 1 : 0;
+    grid.beta = (options.discFlame) ? 1 : 0;
     grid.unburnedLeft = options.unburnedLeft;
 
     // Read initial condition specified in the configuration file

--- a/src/flameSolver.cpp
+++ b/src/flameSolver.cpp
@@ -944,6 +944,7 @@ double FlameSolver::getFlamePosition(void)
 void FlameSolver::loadProfile(void)
 {
     grid.alpha = (options.curvedFlame) ? 1 : 0;
+    grid.beta = (options.axiJetFlame) ? 1 : 0;
     grid.unburnedLeft = options.unburnedLeft;
 
     // Read initial condition specified in the configuration file

--- a/src/flameSolver.cpp
+++ b/src/flameSolver.cpp
@@ -495,7 +495,6 @@ void FlameSolver::resizeAuxiliary()
             system->initialize(nSpec);
             system->setOptions(options);
             system->setTimers(&reactionRatesTimer, &thermoTimer, &jacobianTimer);
-            system->setStrainFunction(strainfunc);
             system->setRateMultiplierFunction(rateMultiplierFunction);
             system->setHeatLossFunction(heatLossFunction);
             system->setRhou(rhou);
@@ -523,6 +522,9 @@ void FlameSolver::resizeAuxiliary()
     convectionSystem.setGrid(grid);
     convectionSystem.resize(nPoints, nSpec, state);
     convectionSystem.setLeftBC(Tleft, Yleft);
+
+    convectionSystem.utwSystem.setStrainFunction(strainfunc);
+    convectionSystem.utwSystem.setRhou(rhou);
 
     if (options.quasi2d) {
         convectionSystem.setupQuasi2D(vzInterp, vrInterp);

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -32,12 +32,14 @@ void OneDimGrid::setOptions(const ConfigOptions& options)
     fixedLeftLoc = options.fixedLeftLoc;
     twinFlame = options.twinFlame;
     curvedFlame = options.curvedFlame;
+    axiJetFlame = options.axiJetFlame;
 
     boundaryTol = options.boundaryTol;
     boundaryTolRm = options.boundaryTolRm;
     unstrainedDownstreamWidth = options.unstrainedDownstreamWidth;
     addPointCount = options.addPointCount;
     alpha = options.gridAlpha;
+    beta = options.gridBeta;
 }
 
 void OneDimGrid::updateValues()
@@ -856,6 +858,7 @@ GridBased::GridBased()
     , cf(grid.cf)
     , cfp(grid.cfp)
     , alpha(grid.alpha)
+    , beta(grid.beta)
     , nPoints(grid.nPoints)
     , jj(grid.jj)
 {

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -31,8 +31,8 @@ void OneDimGrid::setOptions(const ConfigOptions& options)
     unburnedLeft = options.unburnedLeft;
     fixedLeftLoc = options.fixedLeftLoc;
     twinFlame = options.twinFlame;
-    curvedFlame = options.curvedFlame;
-    axiJetFlame = options.axiJetFlame;
+    cylindricalFlame = options.cylindricalFlame;
+    discFlame = options.discFlame;
 
     boundaryTol = options.boundaryTol;
     boundaryTolRm = options.boundaryTolRm;
@@ -561,7 +561,7 @@ bool OneDimGrid::addLeft(vector<dvector>& y)
         // Add point to the left.
         for (size_t i=0; i<addPointCount; i++) {
             double xLeft = x[0] - sqrt(uniformityTol) * (x[1]-x[0]);
-            if (twinFlame || curvedFlame) {
+            if (twinFlame || cylindricalFlame) {
                 if (x[0] == 0) {
                     break;
                 }

--- a/src/grid.h
+++ b/src/grid.h
@@ -36,7 +36,8 @@ public:
     //! an upper bound on grid spacing to control numerical diffusion.
     dvec dampVal;
 
-    int alpha; //!< Domain curvature parameter. 0: planar, 1: cylindrical
+    int alpha; //!< Domain curvature parameter. 0: planar / disc, 1: cylindrical
+    int beta; //!< Domain curvature parameter. 0: planar / cylindrical; 1: disc
     size_t ju; //!< Index corresponding to the unburned mixture
     size_t jb; //!< Index corresponding to the burned mixture
 
@@ -97,6 +98,9 @@ public:
 
     //! `true` if the flame is curved (corresponding to #alpha = 1)
     bool curvedFlame;
+
+    //! `true` if the flame is opposed axisymmetric jets (corresponding to #beta = 1)
+    bool axiJetFlame;
 
     //! Relative tolerance used to extend the domain in order to satisfy zero-
     //! gradient boundary conditions.
@@ -249,7 +253,8 @@ protected:
     dvec& cfm; //!< Coefficient for y[j-1] in first centered difference
     dvec& cf; //!< Coefficient for y[j] in first centered difference
     dvec& cfp; //!< Coefficient for y[j+1] in first centered difference
-    int& alpha; //!< curved grid exponent. alpha = 1 for curved flames, 0 for planar flames.
+    int& alpha; //!< curved grid exponent. alpha = 1 for curved flames, 0 for planar flames and axisymmetric jet flames.
+    int& beta; //!< curved grid exponent. beta = 1 for axisymmetric jet flames, 0 for planar flames and curved flames.
 
     size_t& nPoints; //!< number of grid point
     size_t& jj; //!< index of last grid point (`== nPoints-1`)

--- a/src/grid.h
+++ b/src/grid.h
@@ -97,10 +97,10 @@ public:
     bool twinFlame;
 
     //! `true` if the flame is curved (corresponding to #alpha = 1)
-    bool curvedFlame;
+    bool cylindricalFlame;
 
     //! `true` if the flame is opposed axisymmetric jets (corresponding to #beta = 1)
-    bool axiJetFlame;
+    bool discFlame;
 
     //! Relative tolerance used to extend the domain in order to satisfy zero-
     //! gradient boundary conditions.

--- a/src/readConfig.h
+++ b/src/readConfig.h
@@ -52,6 +52,9 @@ public:
     //! If specified, the leftmost grid point will not extend beyond x = 0.
     bool twinFlame;
 
+    //! [general.axiJetFlame] Set to true for the axisymmetric jet flame configuration.
+    bool axiJetFlame;
+
     ContinuityBoundaryCondition::BC continuityBC;
 
     //! [general.curvedFlame] Set to true for the twin flame configuration.
@@ -156,7 +159,8 @@ public:
     double tEndMin; //!< [terminationCondition.tMin]
     bool haveTStart;
 
-    int gridAlpha; //!< 1 for curved flames, 0 for planar flames
+    int gridAlpha; //!< 1 for curved flames, 0 for planar axisymmetric jet flames
+    int gridBeta; //!< 1 for axisymmetric jet flames, 0 for planar and curved flames
 
     // Controls which variables are included in the outXXXXXX.h5 files
     bool outputProfiles; //!< [outputFiles.saveProfiles]

--- a/src/readConfig.h
+++ b/src/readConfig.h
@@ -52,15 +52,15 @@ public:
     //! If specified, the leftmost grid point will not extend beyond x = 0.
     bool twinFlame;
 
-    //! [general.axiJetFlame] Set to true for the axisymmetric jet flame configuration.
-    bool axiJetFlame;
+    //! [general.discFlame] Set to true for the axisymmetric jet flame configuration.
+    bool discFlame;
 
     ContinuityBoundaryCondition::BC continuityBC;
 
-    //! [general.curvedFlame] Set to true for the twin flame configuration.
+    //! [general.cylindricalFlame] Set to true for the twin flame configuration.
     //! If specified, the leftmost grid point will not extend beyond x = 0.
     //! Also sets #gridAlpha = 1. Otherwise, #gridAlpha = 0.
-    bool curvedFlame;
+    bool cylindricalFlame;
     bool unburnedLeft; //!< [general.unburnedLeft]
     bool fuelLeft; //!< [general.fuelLeft]
 

--- a/src/sourceSystem.cpp
+++ b/src/sourceSystem.cpp
@@ -142,14 +142,11 @@ int SourceSystemCVODE::f(const realtype t, const sdVector& y, sdVector& ydot)
 
     updateThermo();
 
-    double a = strainFunction->a(t);
-    double dadt = strainFunction->dadt(t);
-
     // *** Calculate the time derivatives
     double scale;
     if (!quasi2d) {
         scale = 1.0;
-        dUdt = - U*U + rhou/rho*(dadt/pow(2.0,beta) + a*a/pow(2.0,2*beta)) + splitConst[kMomentum]; //aelong added beta for axiJetflames
+        dUdt = - U*U + splitConst[kMomentum];
         qDot = - (wDot * hk).sum() + getQdotIgniter(t);
         if (heatLoss && options->alwaysUpdateHeatFlux) {
             qDot -= heatLoss->eval(x, t, U, T, Y);
@@ -464,14 +461,11 @@ void SourceSystemQSS::odefun(double t, const dvec& y, dvec& q, dvec& d,
 
     qDot = - ((wDotQ - wDotD) * hk).sum() + getQdotIgniter(t);
 
-    double a = strainFunction->a(t);
-    double dadt = strainFunction->dadt(t);
-
     // *** Calculate the time derivatives
     double scale;
     if (!quasi2d) {
         scale = 1.0;
-        dUdtQ = rhou/rho*(dadt/pow(2.0, beta) + a*a/pow(2.0, 2*beta)) - U*U + splitConst[kMomentum]; //aelong added beta for axiJetflames
+        dUdtQ = splitConst[kMomentum];
         dUdtD = 0;
         dTdtQ = qDot/(rho*cp) + splitConst[kEnergy];
     } else {
@@ -492,8 +486,6 @@ void SourceSystemQSS::odefun(double t, const dvec& y, dvec& q, dvec& d,
 
     assert(rhou > 0);
     assert(rho > 0);
-    assert(dadt > -1e100 && dadt < 1e100);
-    assert(a > -1e100 && a < 1e100);
     assert(U > -1e100 && U < 1e100);
     assert(splitConst[kMomentum] > -1e100 && splitConst[kMomentum] < 1e100);
 

--- a/src/sourceSystem.cpp
+++ b/src/sourceSystem.cpp
@@ -44,6 +44,12 @@ double SourceSystem::getQdotIgniter(double t)
     }
 }
 
+void SourceSystem::setOptions(ConfigOptions& options_)
+{
+    options = &options_;
+    beta = &options_.axiJetFlame;
+}
+
 void SourceSystem::initialize(size_t new_nSpec)
 {
     nSpec = new_nSpec;
@@ -143,7 +149,7 @@ int SourceSystemCVODE::f(const realtype t, const sdVector& y, sdVector& ydot)
     double scale;
     if (!quasi2d) {
         scale = 1.0;
-        dUdt = - U*U + rhou/rho*(dadt + a*a) + splitConst[kMomentum];
+        dUdt = - U*U + rhou/rho*(dadt/pow(2.0,beta) + a*a/pow(2.0,2*beta)) + splitConst[kMomentum]; //aelong added beta for axiJetflames
         qDot = - (wDot * hk).sum() + getQdotIgniter(t);
         if (heatLoss && options->alwaysUpdateHeatFlux) {
             qDot -= heatLoss->eval(x, t, U, T, Y);
@@ -465,7 +471,7 @@ void SourceSystemQSS::odefun(double t, const dvec& y, dvec& q, dvec& d,
     double scale;
     if (!quasi2d) {
         scale = 1.0;
-        dUdtQ = rhou/rho*(dadt + a*a) - U*U + splitConst[kMomentum];
+        dUdtQ = rhou/rho*(dadt/pow(2.0, beta) + a*a/pow(2.0, 2*beta)) - U*U + splitConst[kMomentum]; //aelong added beta for axiJetflames
         dUdtD = 0;
         dTdtQ = qDot/(rho*cp) + splitConst[kEnergy];
     } else {

--- a/src/sourceSystem.cpp
+++ b/src/sourceSystem.cpp
@@ -47,7 +47,7 @@ double SourceSystem::getQdotIgniter(double t)
 void SourceSystem::setOptions(ConfigOptions& options_)
 {
     options = &options_;
-    beta = &options_.axiJetFlame;
+    beta = &options_.discFlame;
 }
 
 void SourceSystem::initialize(size_t new_nSpec)

--- a/src/sourceSystem.h
+++ b/src/sourceSystem.h
@@ -63,7 +63,7 @@ public:
     virtual void initialize(size_t nSpec);
 
     //! Set integrator tolerances and other parameters
-    virtual void setOptions(ConfigOptions& options_) { options = &options_; }
+    virtual void setOptions(ConfigOptions& options_);
 
     void setTimers(PerfTimer* reactionRates, PerfTimer* thermo,
                    PerfTimer* jacobian);
@@ -100,6 +100,7 @@ public:
 
     double U; //!< tangential velocity
     double T; //!< temperature
+    bool beta; //!< curvature parameter for axisymmetric jet flames
     dvec Y; //!< species mass fraction
 
     //! Extra constant term introduced by splitting

--- a/test/test_diffusionSystem.cpp
+++ b/test/test_diffusionSystem.cpp
@@ -11,7 +11,7 @@ public:
         nPoints = 401;
         grid.unburnedLeft = true;
         grid.fixedBurnedVal = true;
-        grid.curvedFlame = false;
+        grid.cylindricalFlame = false;
         grid.twinFlame = false;
         grid.alpha = 0;
         grid.setSize(nPoints);
@@ -85,7 +85,7 @@ TEST_F(DiffusionSystemTest, CylindricalCoordinates)
     // Exact solution in cylindrical coordinates. Same shape as the Cartesian
     // case, but decays as 1/t instead of 1/sqrt(t).
 
-    grid.curvedFlame = true;
+    grid.cylindricalFlame = true;
     grid.alpha = 1;
     grid.fixedBurnedVal = true;
     grid.unburnedLeft = false;


### PR DESCRIPTION
The first commit adds the option for 'axiJetFlame' under general similar to 'twinFlame' and 'curvedFlame.' 

The second commit moves the strain dependent terms from sourceSystem to convectionSystem. This causes a small decrease in computation time.