### PR TITLE
Added unity Lewis Number support

### DIFF
--- a/python/ember/input.py
+++ b/python/ember/input.py
@@ -364,8 +364,8 @@ class Chemistry(Options):
     #: the desired phase is not the first phase defined in the input file.
     phaseID = StringOption("", level=1)
 
-    #: Transport model to use. Valid options are ``Mix``, ``Multi``, and ``Approx``
-    transportModel = StringOption("Approx", ("Mix", "Multi"), level=1)
+    #: Transport model to use. Valid options are ``Mix``, ``Multi``, ``UnityLewis``, and ``Approx``
+    transportModel = StringOption("Approx", ("Mix", "Multi", "UnityLewis"), level=1)
 
     #: Kinetics model to use. Valid options are ``standard`` and ``interp``.
     kineticsModel = StringOption("interp", ("standard",), level=2)

--- a/src/chemistry0d.cpp
+++ b/src/chemistry0d.cpp
@@ -6,6 +6,7 @@
 #include "cantera/kinetics/importKinetics.h"
 #include "cantera/transport/MixTransport.h"
 #include "cantera/transport/MultiTransport.h"
+#include "cantera/transport/UnityLewisTransport.h"
 
 ApproxMixTransport::ApproxMixTransport()
     : _threshold(0.0)
@@ -396,6 +397,8 @@ void CanteraGas::initialize()
         transport = new Cantera::MultiTransport();
     } else if (transportModel == "Mix") {
         transport = new Cantera::MixTransport();
+    } else if (transportModel == "UnityLewis") {
+        transport = new Cantera::UnityLewisTransport();
     } else if (transportModel == "Approx") {
         ApproxMixTransport* atran = new ApproxMixTransport();
         atran->setThreshold(transportThreshold);

--- a/src/chemistry0d.h
+++ b/src/chemistry0d.h
@@ -7,6 +7,7 @@
 
 #include "cantera/transport/MixTransport.h"
 #include "cantera/transport/MultiTransport.h"
+#include "cantera/transport/UnityLewisTransport.h"
 #include "cantera/transport/TransportFactory.h"
 #include "cantera/thermo/IdealGasPhase.h"
 #include "cantera/kinetics/GasKinetics.h"


### PR DESCRIPTION
Hey,

I added the unity lewis number transport option to Ember's master branch, since people has been asking for it in Cantera Google Groups, especially for creating adiabatic mixing lines in counter-diffusion flame configurations. 

It directly uses the UnityLewisTransport model available in Cantera>=2.4.0.

